### PR TITLE
Fix `docker-compose.override.yml` file path to all plugins

### DIFF
--- a/flames/elastic/README.md
+++ b/flames/elastic/README.md
@@ -13,16 +13,16 @@ This section will guide you through getting Elastic GUI clients integrated into 
 
 ### DejaVu and Mirage settings
 
-In case of Elastic, the file is `compose/docker-compose.override.yml-elastic-gui`. This file
+In case of Elastic, the file is `flames/elastic/docker-compose.override.yml`. This file
 must be copied into the root of the Devilbox git directory.
     
-You also need the ELK stack. The file is `compose/docker-compose.override.yml-elastic` 
+You also need the ELK stack. The file is `compose/docker-compose.override.yml-elk` 
 must be copied in the root of the Devilbox git directory.
     
 | What        | How and where |
 | ----------- | ------------- |
-| Example compose file  | `compose/docker-compose.override.yml-elastic-gui` | 
-| Example compose file  | `compose/docker-compose.override.yml-elastic` | 
+| Example compose file  | `flames/elastic/docker-compose.override.yml`  | 
+| Example compose file  | `compose/docker-compose.override.yml-elk`     | 
 
 **DejaVu**
 

--- a/flames/revealjs/README.md
+++ b/flames/revealjs/README.md
@@ -11,12 +11,12 @@ This section will guide you through getting Reveal.js integrated into the Devilb
 
 ### Reveal.js settings
 
-In case of Reveal.js, the file is `compose/docker-compose.override.yml-revealjs`. This file
+In case of Reveal.js, the file is `flames/revealjs/docker-compose.override.yml`. This file
 must be copied into the root of the Devilbox git directory.
     
 | What        | How and where |
 | ----------- | ------------- |
-| Example compose file  | `compose/docker-compose.override.yml-revealjs` | 
+| Example compose file  | `flames/revealjs/docker-compose.override.yml` | 
 
 **Reveal.js**
 

--- a/flames/selenium/README.md
+++ b/flames/selenium/README.md
@@ -12,12 +12,12 @@ This section will guide you through getting Selenium integrated into the Devilbo
 
 ### Selenium settings
 
-In case of Selenium, the file is ``compose/docker-compose.override.yml-selenium``. This file
+In case of Selenium, the file is `flames/selenium/docker-compose.override.yml`. This file
 must be copied into the root of the Devilbox git directory.
     
 | What        | How and where |
 | ----------- | ------------- |
-| Example compose file  | `compose/docker-compose.override.yml-selenium` | 
+| Example compose file  | `flames/selenium/docker-compose.override.yml` | 
 
 **Selenium Hub**
 

--- a/flames/swaggerapi/README.md
+++ b/flames/swaggerapi/README.md
@@ -13,12 +13,12 @@ This section will guide you through getting Swagger API integrated into the Devi
 
 ### Swagger-UI and Swagger-Editor settings
 
-In case of SwaggerAPI, the file is `compose/docker-compose.override.yml-swagger-api`. This file
+In case of SwaggerAPI, the file is `flames/swaggerapi/docker-compose.override.yml`. This file
 must be copied into the root of the Devilbox git directory.
     
 | What        | How and where |
 | ----------- | ------------- |
-| Example compose file  | `compose/docker-compose.override.yml-swagger-api` | 
+| Example compose file  | `flames/swaggerapi/docker-compose.override.yml` | 
 
 **Swagger-UI**
 


### PR DESCRIPTION
Hello,

I think it will be better to have `docker-compose.override.yml` file path prefixed by **devilbox/flames** origin.
Reason: these additionals plugins are not included in devilbox base code (`compose/` folder)

Laurent